### PR TITLE
Fix region and isp name encoding

### DIFF
--- a/telize
+++ b/telize
@@ -120,6 +120,16 @@ server {
 			args.city = cd:iconv(args.city)
 		end
 
+		-- Convert region name to UTF-8 if it exists
+		if args.region ~= nil then
+			args.region = cd:iconv(args.region)
+		end
+
+		-- Convert isp name to UTF-8 if it exists
+		if args.isp ~= nil then
+			args.isp = cd:iconv(args.isp)
+		end
+
 		if args.ip == "127.0.0.1" then
 			ngx.status = ngx.HTTP_BAD_REQUEST
 			ngx.say(cjson.encode({code = 401, message = "Input string is not a valid IP address"}))


### PR DESCRIPTION
http://www.telize.com/geoip/200.185.80.111 do not seems to return an utf-8 string